### PR TITLE
feature: Token regeneration

### DIFF
--- a/src/AuthenticationException.php
+++ b/src/AuthenticationException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Teemill\ImageApi;
+
+use RuntimeException;
+
+class AuthenticationException extends RuntimeException
+{
+    public static function tokenExpired(): AuthenticationException
+    {
+        return new static('Authentication token expired.');
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,8 +30,7 @@ class Client
         ClientInterface $client,
         string          $secret,
         ?int            $token_expiration = null
-    )
-    {
+    ) {
         $this->secret = $secret;
         $this->client = $client;
 
@@ -137,8 +136,7 @@ class Client
         string $method,
         string $resource,
         array  $data = []
-    ): ResponseInterface
-    {
+    ): ResponseInterface {
         try {
             JWT::decode($this->token, $this->secret, [static::algorithm]);
         } catch (ExpiredException $exception) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,8 +1,12 @@
 <?php
 
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Teemill\ImageApi\AuthenticationException;
 use Teemill\ImageApi\Client as ApiClient;
 use Teemill\ImageApi\Exceptions\ClientResponseException;
+use GuzzleHttp\Client as MockClient;
 
 uses()->group('client');
 
@@ -21,6 +25,40 @@ it('can be instantiated with credentials', function () {
 
     expect($client)->toBeInstanceOf(ApiClient::class);
 });
+
+it('throws an exception when using an expired key', function () {
+    $client = new ApiClient(
+        new MockClient([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, []),
+            ])),
+        ]),
+        'secret',
+        strtotime('-1 day') // Expired
+    );
+
+    $client->upload('example.jpg', 'example');
+})->throws(AuthenticationException::class, 'Authentication token expired.');
+
+it('can generate an authentication token', function () {
+    $client = new ApiClient(
+        new MockClient([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, []),
+            ])),
+        ]),
+        'secret',
+    );
+
+    $old_token = $client->token;
+
+    expect($old_token)->not->toBeNull();
+
+    $client->generateAuthenticationToken(strtotime('+5 minutes'));
+
+    expect($client)->token->not->toEqual($old_token);
+});
+
 it('can upload an image to a specified directory', function () {
     $client = createMockClient([
         new Response(200, [], json_encode([

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,12 +1,12 @@
 <?php
 
+use GuzzleHttp\Client as MockClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Teemill\ImageApi\AuthenticationException;
 use Teemill\ImageApi\Client as ApiClient;
 use Teemill\ImageApi\Exceptions\ClientResponseException;
-use GuzzleHttp\Client as MockClient;
 
 uses()->group('client');
 


### PR DESCRIPTION
# Purpose:
Adds an exception that triggers when the token has expired. This allows applications that cache the client in memory to handle the case where a token expires before the process has ended - and regenerated the class.