### PR TITLE
refactor: remove token caching and regeneration

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -26,39 +26,6 @@ it('can be instantiated with credentials', function () {
     expect($client)->toBeInstanceOf(ApiClient::class);
 });
 
-it('throws an exception when using an expired key', function () {
-    $client = new ApiClient(
-        new MockClient([
-            'handler' => HandlerStack::create(new MockHandler([
-                new Response(200, []),
-            ])),
-        ]),
-        'secret',
-        strtotime('-1 day') // Expired
-    );
-
-    $client->upload('example.jpg', 'example');
-})->throws(AuthenticationException::class, 'Authentication token expired.');
-
-it('can generate an authentication token', function () {
-    $client = new ApiClient(
-        new MockClient([
-            'handler' => HandlerStack::create(new MockHandler([
-                new Response(200, []),
-            ])),
-        ]),
-        'secret',
-    );
-
-    $old_token = $client->token;
-
-    expect($old_token)->not->toBeNull();
-
-    $client->generateAuthenticationToken(strtotime('+5 minutes'));
-
-    expect($client)->token->not->toEqual($old_token);
-});
-
 it('can upload an image to a specified directory', function () {
     $client = createMockClient([
         new Response(200, [], json_encode([

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,10 +1,6 @@
 <?php
 
-use GuzzleHttp\Client as MockClient;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
-use Teemill\ImageApi\AuthenticationException;
 use Teemill\ImageApi\Client as ApiClient;
 use Teemill\ImageApi\Exceptions\ClientResponseException;
 


### PR DESCRIPTION
# Purpose:
Removes a feature that was intended to improve performance by caching auth tokens. In reality this just complicates requests by making token expiry difficult to circumvent.

### Changes:
- Removes the memory caching ability of the client in singleton containers
- Adds a separate `sendAuthenticatedClientRequest` that applies the authorization header
- Reformatting and renaming of methods and properties to be more explicit


